### PR TITLE
onRequest and sendRequest deprecated in v20 (dev branch)

### DIFF
--- a/background.js
+++ b/background.js
@@ -35,7 +35,7 @@ function updateTabs() {
           'scheme': getSiteScheme(siteFromUrl(url)),
           'modifiers': getModifiers()
         };
-        chrome.tabs.sendRequest(tabs[j].id, msg);
+        chrome.tabs.sendMessage(tabs[j].id, msg);
       }
     }
   });
@@ -64,7 +64,7 @@ function init() {
   injectContentScripts();
   updateTabs();
 
-  chrome.extension.onRequest.addListener(
+  chrome.runtime.onMessage.addListener(
       function(request, sender, sendResponse) {
         if (request['toggle_global']) {
           toggleEnabled();

--- a/deluminate.js
+++ b/deluminate.js
@@ -11,14 +11,14 @@ function onExtensionMessage(request) {
 function onEvent(evt) {
   if (evt.keyCode == 122 /* F11 */ &&
       evt.shiftKey) {
-    chrome.extension.sendRequest({'toggle_global': true});
+    chrome.runtime.sendMessage({'toggle_global': true});
     evt.stopPropagation();
     evt.preventDefault();
     return false;
   }
   if (evt.keyCode == 123 /* F12 */ &&
       evt.shiftKey) {
-    chrome.extension.sendRequest({'toggle_site': true});
+    chrome.runtime.sendMessage({'toggle_site': true});
     evt.stopPropagation();
     evt.preventDefault();
     return false;
@@ -32,8 +32,8 @@ function init() {
   } else {
     scheme_prefix = 'nested_';
   }
-  chrome.extension.onRequest.addListener(onExtensionMessage);
-  chrome.extension.sendRequest({'init': true}, onExtensionMessage);
+  chrome.runtime.onMessage.addListener(onExtensionMessage);
+  chrome.runtime.sendMessage({'init': true}, onExtensionMessage);
   document.addEventListener('keydown', onEvent, false);
 }
 


### PR DESCRIPTION
fixes broken api calls for v29.. onRequest and sendRequest deprecated in v20. 

I was going to include a backward compatibility for <= v19, but there was a chicken and egg problem with sending the browser version to the background page so I didn't bother.
