### PR TITLE
Don't force lowestVisiblePoint conversion to px

### DIFF
--- a/deluminate.js
+++ b/deluminate.js
@@ -164,8 +164,8 @@ function resetFullscreenWorkaroundHeight() {
     window.scrollY + window.innerHeight;
   var rightestVisiblePoint =
     window.scrollX + window.innerWidth;
-  fullscreen_workaround.style.height = lowestVisiblePoint + 'px';
-  fullscreen_workaround.style.width = rightestVisiblePoint + 'px';
+  fullscreen_workaround.style.height = lowestVisiblePoint;
+  fullscreen_workaround.style.width = rightestVisiblePoint;
 
   // Yield to the renderer, then reset the size to the calculated region.
   setTimeout(() => {


### PR DESCRIPTION
This seems to prevent blinking with Chrome 0.58 - 0.61.