### PR TITLE
Allows user to edit and save site customizations in extension settings.

### DIFF
--- a/deluminate.js
+++ b/deluminate.js
@@ -54,7 +54,7 @@ function onExtensionMessage(request) {
 function injectInstantInversion() {
   // This results in a more instant, if imperfect, inversion. Injected CSS
   // apparently takes a moment to be processed.
-  document.documentElement.style.filter = "hue-rotate(180deg) invert()";
+  document.documentElement.style.filter = "hue-rotate(180deg) invert(100%)";
   afterDomLoaded(() => {
     // Restore filter control to the injected CSS.
     document.documentElement.style.filter = "";

--- a/deluminate.js
+++ b/deluminate.js
@@ -54,7 +54,7 @@ function onExtensionMessage(request) {
 function injectInstantInversion() {
   // This results in a more instant, if imperfect, inversion. Injected CSS
   // apparently takes a moment to be processed.
-  document.documentElement.style.filter = "hue-rotate(180deg) invert(100%)";
+  document.documentElement.style.filter = "hue-rotate(180deg) invert()";
   afterDomLoaded(() => {
     // Restore filter control to the injected CSS.
     document.documentElement.style.filter = "";

--- a/options.html
+++ b/options.html
@@ -63,6 +63,8 @@ label {
 
 <button id="forget">Forget site customizations</button>
 
+<button id="edit-save">Edit site customizations</button>
+
 <hr>
 <a href="https://github.com/abstiles/deluminate/issues/new" id="issues">
   Something wrong? Let me know!

--- a/options.html
+++ b/options.html
@@ -62,6 +62,7 @@ label {
 <textarea readonly id="settings"></textarea>
 
 <button id="forget">Forget site customizations</button>
+<button id="edit-save" onclick="editSaveCustomizations()">Edit site customizations</button>
 
 <hr>
 <a href="https://github.com/abstiles/deluminate/issues/new" id="issues">

--- a/options.html
+++ b/options.html
@@ -62,7 +62,6 @@ label {
 <textarea readonly id="settings"></textarea>
 
 <button id="forget">Forget site customizations</button>
-<button id="edit-save" onclick="editSaveCustomizations()">Edit site customizations</button>
 
 <hr>
 <a href="https://github.com/abstiles/deluminate/issues/new" id="issues">

--- a/options.js
+++ b/options.js
@@ -38,21 +38,6 @@ function loadSettingsDisplay() {
   $('settings').value = JSON.stringify(settings, null, 4);
 }
 
-function editSaveCustomizations() {
-  let editSaveButton = document.getElementById('edit-save');
-  let settingsText = document.getElementById('settings');
-
-  if(editSaveButton.textContent === 'Save site customizations') {
-    editSaveButton.textContent = 'Edit site customizations';
-    settingsText.readOnly = true;
-    localStorage['siteschemes'] = JSON.stringify(JSON.parse(settingsText.value).schemes);
-    localStorage['sitemodifiers'] = JSON.stringify(JSON.parse(settingsText.value).modifiers);
-  } else {
-    editSaveButton.textContent = 'Save site customizations';
-    settingsText.readOnly = false;
-  }
-}
-
 function init() {
   initSettings();
   $('forget').addEventListener('click', onForget, false);

--- a/options.js
+++ b/options.js
@@ -42,7 +42,7 @@ function onEditSave() {
   let editSaveButton = document.getElementById('edit-save');
   let settingsText = document.getElementById('settings');
 
-  if(editSaveButton.textContent === 'Save site customizations') {
+  if (!settingsText.readOnly) {
     editSaveButton.textContent = 'Edit site customizations';
     settingsText.readOnly = true;
     localStorage['siteschemes'] = JSON.stringify(JSON.parse(settingsText.value).schemes);

--- a/options.js
+++ b/options.js
@@ -38,9 +38,25 @@ function loadSettingsDisplay() {
   $('settings').value = JSON.stringify(settings, null, 4);
 }
 
+function onEditSave() {
+  let editSaveButton = document.getElementById('edit-save');
+  let settingsText = document.getElementById('settings');
+
+  if(editSaveButton.textContent === 'Save site customizations') {
+    editSaveButton.textContent = 'Edit site customizations';
+    settingsText.readOnly = true;
+    localStorage['siteschemes'] = JSON.stringify(JSON.parse(settingsText.value).schemes);
+    localStorage['sitemodifiers'] = JSON.stringify(JSON.parse(settingsText.value).modifiers);
+  } else {
+    editSaveButton.textContent = 'Save site customizations';
+    settingsText.readOnly = false;
+  }
+}
+
 function init() {
   initSettings();
   $('forget').addEventListener('click', onForget, false);
+  $('edit-save').addEventListener('click', onEditSave, false);
   $('detect_animation').addEventListener('change', onDetectAnim, false);
   loadSettingsDisplay();
 }

--- a/options.js
+++ b/options.js
@@ -38,6 +38,21 @@ function loadSettingsDisplay() {
   $('settings').value = JSON.stringify(settings, null, 4);
 }
 
+function editSaveCustomizations() {
+  let editSaveButton = document.getElementById('edit-save');
+  let settingsText = document.getElementById('settings');
+
+  if(editSaveButton.textContent === 'Save site customizations') {
+    editSaveButton.textContent = 'Edit site customizations';
+    settingsText.readOnly = true;
+    localStorage['siteschemes'] = JSON.stringify(JSON.parse(settingsText.value).schemes);
+    localStorage['sitemodifiers'] = JSON.stringify(JSON.parse(settingsText.value).modifiers);
+  } else {
+    editSaveButton.textContent = 'Save site customizations';
+    settingsText.readOnly = false;
+  }
+}
+
 function init() {
   initSettings();
   $('forget').addEventListener('click', onForget, false);


### PR DESCRIPTION
Removes style filter invert method, which fixes the invert issue (#602 to name one) Chrome 65 introduced.  Adds edit/save button for site customizations to Deluminate Options tab.  Toggles settings textarea's readonly property, then saves the scheme and modifier values to localStorage.
Potential fix for [issue #603](https://github.com/abstiles/deluminate/issues/603).