### PR TITLE
Add Firefox support

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,6 +1,11 @@
 var DEFAULT_SCHEME = "delumine-smart";
 var DEFAULT_MODS = [];
 
+// In firefox, alias global chrome variable to firefox equivalent
+if ((typeof chrome === 'undefined') && (typeof browser !== 'undefined')) {
+  var chrome = browser;
+}
+
 function $(id) {
   return document.getElementById(id);
 }

--- a/options.html
+++ b/options.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Deluminate Options</title>
+<meta charset="UTF-8">
 <style type="text/css">
 body {
   max-width: 800px;

--- a/popup.html
+++ b/popup.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Deluminate Pop-up</title>
+<meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="deluminate.css" />
 <style type="text/css">
 html {


### PR DESCRIPTION
Firefox 66 is fully compatible with deluminate master branch.
With one small change required.

### Changes
* Global `browser` variable in firefox is aliased to the global `chrome` variable used in the scripts.
* The html files received an explicit charset declaration to supress console warnings in Firefox. Having them there doesn't hurt when running in Chrome.

### Tests performed before pull request:
* Ran the `npm test` and all tests pass.
* Deployed and manually tested the extension to firefox using `web-ext run` as well as a _signed extension_, from my private mozilla addons account, to a vanilla Firefox 66 browser.
* Tested that the shortcut works (Shift F11) as that has been mentioned as not working previously in the issue list (#379). It works perfectly fine now.

### Note
* The `-webkit-` CSS selectors used in the style sheet are compatible with Firefox, as the browser [supports that prefix](https://developer.mozilla.org/en-US/docs/Web/CSS/appearance) as well. I.e. no need to introduce moz-specific prefixes.

Finally, I'm super happy I can now use your extension full time in Firefox as well. Thanks for creating the extension.