### PR TITLE
Fix dark mode toggling when service worker restarts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ package-lock.json
 
 # Test output
 spec/**/*.xml
+
+.vscode/


### PR DESCRIPTION
This refactors the service worker initialization to address a race condition in Manifest V3. An initializationCompletePromise is introduced to ensure that all settings are loaded from storage via syncStore() before the extension processes messages or responds to events like tab updates or commands. This prevents the extension from intermittently applying the dark theme when disabled, which could occur if an action was handled before settings were fully populated after a service worker restart. Key message handlers and event listeners now await this promise, ensuring operations are based on the correct, loaded state.

I've loaded this into my Chrome and used it for a couple of hours, and it worked well. It also didn't generate any errors (via the Collect errors option).

Fixes #794 and #798.